### PR TITLE
Use non-deprecated `license` format

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,5 @@
   "bugs": {
     "url": "https://github.com/Constellation/boundary/issues"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://github.com/Constellation/boundary/raw/master/LICENSE.BSD"
-    }
-  ]
+  "license": "BSD-2-Clause"
 }


### PR DESCRIPTION
As with https://github.com/Constellation/structured-source/pull/3